### PR TITLE
Work around sorl issues

### DIFF
--- a/forest/templates/pageblocks/imageblock.html
+++ b/forest/templates/pageblocks/imageblock.html
@@ -1,0 +1,6 @@
+{% load markup %}
+
+<img alt="{{block.alt}}" src="{{MEDIA_URL}}{{block.image.name}}" />
+<div class="caption">
+{{block.caption|markdown}}
+</div>

--- a/forest/templates/pageblocks/imageblock_summary.html
+++ b/forest/templates/pageblocks/imageblock_summary.html
@@ -1,0 +1,1 @@
+<img alt="{{block.alt}}" src="{{MEDIA_URL}}{{block.image.name}}" style="width: 100px; height: auto;"/>


### PR DESCRIPTION
Pagetree apps that serve off of S3 and continue to use ImageBlock need to remove thumbnail references.

See https://github.com/ccnmtl/django-pageblocks/issues/5 for more information.