### PR TITLE
add smoketest to ensure existence of seed stand

### DIFF
--- a/forest/main/smoke.py
+++ b/forest/main/smoke.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from smoketest import SmokeTest
 from models import Stand
 
@@ -5,4 +6,10 @@ from models import Stand
 class DBConnectivity(SmokeTest):
     def test_retrieve(self):
         cnt = Stand.objects.all().count()
+        self.assertTrue(cnt > 0)
+
+
+class SeedStandExists(SmokeTest):
+    def test_seed_stand(self):
+        cnt = Stand.objects.get(hostname=settings.SEED_STAND)
         self.assertTrue(cnt > 0)


### PR DESCRIPTION
forest requires a "seed" stand, "forest.ccnmtl.columbia.edu" to exist,
from which other stands can be created/managed. this adds a smoketest
that makes sure that the configured seed stand exists so we'd get an
alert if that invariant ever changes.