### PR TITLE
:arrow_up: Django 1.9.5

### DIFF
--- a/forest/main/models.py
+++ b/forest/main/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.contrib.auth.models import User, Group
 import hashlib
-from django.db.models import get_model
+from django.apps import apps
 from django.conf import settings
 from pagetree.helpers import get_section_from_path
 
@@ -43,7 +43,7 @@ class Stand(models.Model):
 
     def available_pageblocks(self):
         enabled = [pb.block for pb in self.standavailablepageblock_set.all()]
-        return [get_model(*pb.split('.')) for pb in settings.PAGEBLOCKS
+        return [apps.get_model(*pb.split('.')) for pb in settings.PAGEBLOCKS
                 if pb in enabled]
 
     def get_root(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 --index-url https://pypi.ccnmtl.columbia.edu/
-Django==1.8.12
+Django==1.9.5
 lxml==3.4.4
 feedparser==5.2.0
 Markdown==2.6.6
@@ -64,16 +64,16 @@ django-careermapblock==0.3.0
 django-fridgeblock==0.4.0
 django-appconf==1.0.2
 django-compressor==1.5
-django-statsd-mozilla==0.3.15
+django-statsd-mozilla==0.3.16
 django-bootstrap-form==3.2
-django-debug-toolbar==1.3.2
+django-debug-toolbar==1.4
 django-smoketest==1.0.0
 django-jenkins==0.18.1
 django-stagingcontext==0.1.0
 django-waffle==0.11
 django-impersonate==1.0.1
 django-extensions==1.6.1
-django-likertblock==0.2.0
+django-likertblock==0.3.0
 gunicorn==19.4.5
 django-ga-context==0.1.0
 django-storages-redux==1.3.2


### PR DESCRIPTION
may require a `./manage.py migrate likertblock --fake-initial` as that upgraded from south migrations.