### PR TITLE
switch from WIND to CAS

### DIFF
--- a/forest/settings_shared.py
+++ b/forest/settings_shared.py
@@ -77,11 +77,4 @@ if 'test' in sys.argv or 'jenkins' in sys.argv:
         ('text/less', 'node_modules/less/bin/lessc {infile} {outfile}'),
     )
 
-# WIND settings
-
-AUTHENTICATION_BACKENDS = ('djangowind.auth.WindAuthBackend',
-                           'django.contrib.auth.backends.ModelBackend',)
-WIND_BASE = "https://wind.columbia.edu/"
-WIND_SERVICE = "cnmtl_full_np"
-
 SEED_STAND = "test.example.com"

--- a/forest/templates/admin/login.html
+++ b/forest/templates/admin/login.html
@@ -15,11 +15,11 @@
 <p class="errornote">{{ error_message }}</p>
 {% endif %}
 <div id="content-main">
-<form method="get" action="https://wind.columbia.edu/login">
+<form method="get" action="https://cas.columbia.edu/cas/login">
 <input type="hidden" name="service" value="cnmtl_full_np" />
-<input type="hidden" name="destination" value="http{% if request.is_secure %}s{% endif %}://{{ request.get_host }}/accounts/windlogin/?next=/admin/&this_is_the_login_form=1" />
+<input type="hidden" name="destination" value="https://{{ request.get_host }}/accounts/caslogin/?next=/admin/&this_is_the_login_form=1" />
 <p>If you have a Columbia UNI, you already have an account and can
-login through WIND with it</p>
+login through CAS with it</p>
 <input type="submit" value="Here" />
 </form>
 <p>otherwise: </p>

--- a/forest/templates/registration/login.html
+++ b/forest/templates/registration/login.html
@@ -32,10 +32,9 @@ input[type='text'], input[type='password'] {
 <div class="span6">
     <h3>Choose a Login Option...</h3>
     
-    <form method="get" action="{{ wind_base }}login" class="well">
+    <form method="get" action="{{CAS_BASE}}cas/login" class="well">
     
-    <input type="hidden" name="service" value="{{ wind_service }}" />
-    <input type="hidden" name="destination" value="http{% if request.is_secure %}s{% endif %}://{{ request.get_host }}/accounts/windlogin/?next={{ next }}" />
+    <input type="hidden" name="destination" value="https://{{ request.get_host }}/accounts/caslogin/?next={{ next }}" />
     <p>If you have a Columbia University Network ID
     	(UNI)... </p><input type="submit" value="Columbia Log In" class="btn btn-primary"/></p>
     </form>


### PR DESCRIPTION
per PMT #95714.

All the existing stand hostnames are registered. Unfortunately, they
still won't do wildcards, so anyone creating a new stand won't be able
to log into it until we send in the request. Forest doesn't seem to be
heavily used anymore though so I guess that's not a high priority.

After this goes through, I'll probably add a bit that just warns the
user creating a new stand that it needs to be registered with CAS, and
then sends an email to ccnmtl-sysadmin so we can put in the request. I
guess we could also get fancy and send it directly to Dan plexus-style,
but I'm not sure that's really worth it given how infrequently new
stands are now created.