### PR TITLE
update mathjax CDN URL

### DIFF
--- a/forest/templates/base.html
+++ b/forest/templates/base.html
@@ -32,7 +32,7 @@
 	<link rel="stylesheet" type="text/css" href="/_stand/css/?hash={{stand.css_hash}}"
 	{% endif %}
 	{% endif %}
-  <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 </head>
 <body class="{% block bodyclass %}{% endblock %}" id="{% block bodyid %}{% endblock %}">
 


### PR DESCRIPTION
https://www.mathjax.org/cdn-shutting-down/